### PR TITLE
DVX-151: Adjust typescript front to new default tenant in Noumena Cloud

### DIFF
--- a/cloud.mk
+++ b/cloud.mk
@@ -96,6 +96,7 @@ download-cli:
 create-app:
 	./cli app create -org $(NC_ORG) -engine $(NC_ENGINE_VERSION) -name $(NC_APP_NAME) -provider MicrosoftAzure -trusted_issuers '["https://keycloak-$(NC_ORG_NAME)-$(NC_APP_NAME).$(NC_DOMAIN)/realms/$(NC_APP_NAME)"]'
 
+.PHONY: clear-deploy
 clear-deploy: zip
 	@if [ "$(NC_APP)" = "" ] ; then echo "App $(NC_APP_NAME) not found"; exit 1; fi
 	@if [ "$(NPL_VERSION)" = "" ]; then echo "NPL_VERSION not set"; exit 1; fi

--- a/npl/src/main/npl-1.0/iou/iou.npl
+++ b/npl/src/main/npl-1.0/iou/iou.npl
@@ -51,9 +51,10 @@ protocol[issuer, payee] Iou(var description: Text, var forAmount: Number) {
         };
     };
 
-//    @api
-//    permission[issuer] doSomething()  {
-//    };
+    // Dummy permission to illustrate new API endpoint generation
+    /*@api
+    permission[issuer] doSomething()  {
+    };*/
 
     @api
     permission[payee] forgive() | unpaid {

--- a/npl/src/main/npl-1.0/iou/iou.npl
+++ b/npl/src/main/npl-1.0/iou/iou.npl
@@ -51,6 +51,10 @@ protocol[issuer, payee] Iou(var description: Text, var forAmount: Number) {
         };
     };
 
+//    @api
+//    permission[issuer] doSomething()  {
+//    };
+
     @api
     permission[payee] forgive() | unpaid {
         become forgiven;

--- a/python-listener/src/stream.py
+++ b/python-listener/src/stream.py
@@ -119,5 +119,4 @@ class StreamReader:
             print("unrecognized state event", event)
 
     def manage_payment_confirmation_required_state_change(self, payload: Payload):
-        # print("TODO complete implementation according to the business use-case")
         pass

--- a/python-listener/src/stream.py
+++ b/python-listener/src/stream.py
@@ -119,5 +119,5 @@ class StreamReader:
             print("unrecognized state event", event)
 
     def manage_payment_confirmation_required_state_change(self, payload: Payload):
-        print("TODO complete implementation according to the business use-case")
+        # print("TODO complete implementation according to the business use-case")
         pass

--- a/webapp/public/config-noumena-cloud.json
+++ b/webapp/public/config-noumena-cloud.json
@@ -1,4 +1,4 @@
 {
-    "API_BASE_URL": "https://engine-training-nplintegrations.noumena.cloud",
-    "KEYCLOAK_URL": "https://keycloak-training-nplintegrations.noumena.cloud"
+    "API_BASE_URL": "https://engine-noumena-nplintegrations.noumena.cloud",
+    "KEYCLOAK_URL": "https://keycloak-noumena-nplintegrations.noumena.cloud"
 }


### PR DESCRIPTION
* Set tenant to noumena in typescript frontend configuration file for Noumena Cloud (note that if the APP name on Noumena Cloud differs from nplintegrations, adjustments are currently required in KeycloakProvider.tsx whenever switching between local deployment with docker and integration with PaaS-deployed engine)
* Reintroduce dummy permission to illustrate API endpoint generation